### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisioner.java
+++ b/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisioner.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceConfigurationProperties.java
+++ b/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceConfigurationProperties.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceJmsConfiguration.java
+++ b/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceJmsConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisionerIntegrationTests.java
+++ b/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisionerIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceTestUtils.java
+++ b/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceTestUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisioner.java
+++ b/src/main/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisioner.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceConfigurationProperties.java
+++ b/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceConfigurationProperties.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceJmsConfiguration.java
+++ b/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceJmsConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceBinderTests.java
+++ b/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceBinderTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisionerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisionerIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceTestBinder.java
+++ b/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceTestBinder.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceTestUtils.java
+++ b/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceTestUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 12 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).